### PR TITLE
Add automated release CI/CD workflow

### DIFF
--- a/.github/setup-labels.sh
+++ b/.github/setup-labels.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Setup labels for automated release workflow
+# Usage: bash .github/setup-labels.sh
+
+echo "Setting up GitHub labels for automated release workflow..."
+
+# Release type labels
+gh label create "release:major" --description "Major version bump (breaking changes)" --color "b60205" 2>/dev/null || echo "Label 'release:major' already exists"
+gh label create "release:minor" --description "Minor version bump (new features)" --color "0e8a16" 2>/dev/null || echo "Label 'release:minor' already exists"
+gh label create "release:patch" --description "Patch version bump (bug fixes)" --color "fbca04" 2>/dev/null || echo "Label 'release:patch' already exists"
+gh label create "release:skip" --description "Skip automatic release" --color "eeeeee" 2>/dev/null || echo "Label 'release:skip' already exists"
+
+# PR categorization labels
+gh label create "breaking-change" --description "Breaking change" --color "d73a4a" 2>/dev/null || echo "Label 'breaking-change' already exists"
+gh label create "feature" --description "New feature" --color "a2eeef" 2>/dev/null || echo "Label 'feature' already exists"
+gh label create "enhancement" --description "Enhancement to existing feature" --color "84b6eb" 2>/dev/null || echo "Label 'enhancement' already exists"
+gh label create "bug" --description "Bug fix" --color "d73a4a" 2>/dev/null || echo "Label 'bug' already exists"
+gh label create "fix" --description "General fix" --color "d4c5f9" 2>/dev/null || echo "Label 'fix' already exists"
+gh label create "documentation" --description "Documentation changes" --color "0075ca" 2>/dev/null || echo "Label 'documentation' already exists"
+gh label create "ci" --description "CI/CD changes" --color "555555" 2>/dev/null || echo "Label 'ci' already exists"
+
+echo "✅ Label setup complete!"
+echo ""
+echo "Usage:"
+echo "1. When creating a PR, add one of these labels:"
+echo "   - release:major - For breaking changes (1.0.0 → 2.0.0)"
+echo "   - release:minor - For new features (1.0.0 → 1.1.0)"
+echo "   - release:patch - For bug fixes (1.0.0 → 1.0.1)"
+echo "   - release:skip - To skip automatic release"
+echo ""
+echo "2. Additionally, categorize your PR with:"
+echo "   - breaking-change - For breaking changes"
+echo "   - feature/enhancement - For new features or improvements"
+echo "   - bug/fix - For bug fixes"
+echo "   - documentation - For docs changes"
+echo "   - ci - For CI/CD changes"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,125 @@
+name: Prepare Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  create-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR labels
+        id: labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            console.log('PR labels:', labels);
+            
+            const releaseLabel = labels.find(label => label.startsWith('release:'));
+            if (!releaseLabel) {
+              console.log('No release label found, skipping release');
+              return 'skip';
+            }
+            
+            const releaseType = releaseLabel.split(':')[1];
+            if (!['major', 'minor', 'patch'].includes(releaseType)) {
+              console.log(`Invalid release type: ${releaseType}`);
+              return 'skip';
+            }
+            
+            return releaseType;
+          result-encoding: string
+
+      - name: Get latest tag
+        if: steps.labels.outputs.result != 'skip'
+        id: latest-tag
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $LATEST_TAG"
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        if: steps.labels.outputs.result != 'skip'
+        id: new-version
+        run: |
+          RELEASE_TYPE="${{ steps.labels.outputs.result }}"
+          LATEST_TAG="${{ steps.latest-tag.outputs.tag }}"
+          
+          # Remove 'v' prefix if present
+          VERSION=${LATEST_TAG#v}
+          
+          # Split version into parts
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          
+          # Calculate new version based on release type
+          case $RELEASE_TYPE in
+            major)
+              NEW_MAJOR=$((MAJOR + 1))
+              NEW_MINOR=0
+              NEW_PATCH=0
+              ;;
+            minor)
+              NEW_MAJOR=$MAJOR
+              NEW_MINOR=$((MINOR + 1))
+              NEW_PATCH=0
+              ;;
+            patch)
+              NEW_MAJOR=$MAJOR
+              NEW_MINOR=$MINOR
+              NEW_PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        if: steps.labels.outputs.result != 'skip'
+        env:
+          NEW_VERSION: ${{ steps.new-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create tag with PR information
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          TAG_MESSAGE="Release $NEW_VERSION
+
+          Auto-generated from PR #$PR_NUMBER: $PR_TITLE"
+          
+          # Create annotated tag
+          git tag -a "$NEW_VERSION" -m "$TAG_MESSAGE"
+          
+          # Push tag
+          git push origin "$NEW_VERSION"
+
+      - name: Comment on PR
+        if: steps.labels.outputs.result != 'skip'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const newVersion = '${{ steps.new-version.outputs.version }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🎉 This PR has been merged and tagged as release \`${newVersion}\`!\n\nThe release workflow will automatically create a GitHub Release with the built artifacts.`
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,113 @@ jobs:
         hdiutil create -volname "CCUsageMac" -srcfolder dmg-temp -ov -format UDZO CCUsageMac-${GITHUB_REF_NAME}.dmg
         rm -rf dmg-temp
         
+    - name: Generate Release Notes
+      id: release-notes
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const tag = context.ref.replace('refs/tags/', '');
+          const { data: previousTags } = await github.rest.repos.listTags({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            per_page: 2
+          });
+          
+          let previousTag = null;
+          if (previousTags.length > 1) {
+            // Current tag is at index 0, previous is at index 1
+            previousTag = previousTags[1].name;
+          }
+          
+          // Get commits between tags
+          const commits = previousTag ? await github.rest.repos.compareCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            base: previousTag,
+            head: tag
+          }) : null;
+          
+          // Get PRs merged since last release
+          const prs = [];
+          if (commits) {
+            for (const commit of commits.data.commits) {
+              const prsForCommit = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: commit.sha
+              });
+              prs.push(...prsForCommit.data);
+            }
+          }
+          
+          // Remove duplicates
+          const uniquePrs = Array.from(new Map(prs.map(pr => [pr.number, pr])).values());
+          
+          // Categorize PRs by labels
+          const features = [];
+          const bugfixes = [];
+          const others = [];
+          const breaking = [];
+          
+          for (const pr of uniquePrs) {
+            const labels = pr.labels.map(l => l.name);
+            if (labels.includes('breaking-change')) {
+              breaking.push(pr);
+            } else if (labels.includes('feature') || labels.includes('enhancement')) {
+              features.push(pr);
+            } else if (labels.includes('bug') || labels.includes('fix')) {
+              bugfixes.push(pr);
+            } else {
+              others.push(pr);
+            }
+          }
+          
+          // Build release notes
+          let notes = `## What's Changed in ${tag}\n\n`;
+          
+          if (breaking.length > 0) {
+            notes += `### ⚠️ Breaking Changes\n`;
+            breaking.forEach(pr => {
+              notes += `- ${pr.title} by @${pr.user.login} in #${pr.number}\n`;
+            });
+            notes += '\n';
+          }
+          
+          if (features.length > 0) {
+            notes += `### ✨ New Features\n`;
+            features.forEach(pr => {
+              notes += `- ${pr.title} by @${pr.user.login} in #${pr.number}\n`;
+            });
+            notes += '\n';
+          }
+          
+          if (bugfixes.length > 0) {
+            notes += `### 🐛 Bug Fixes\n`;
+            bugfixes.forEach(pr => {
+              notes += `- ${pr.title} by @${pr.user.login} in #${pr.number}\n`;
+            });
+            notes += '\n';
+          }
+          
+          if (others.length > 0) {
+            notes += `### 📚 Other Changes\n`;
+            others.forEach(pr => {
+              notes += `- ${pr.title} by @${pr.user.login} in #${pr.number}\n`;
+            });
+            notes += '\n';
+          }
+          
+          notes += `\n**Full Changelog**: https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${previousTag || ''}...${tag}`;
+          
+          return notes;
+        result-encoding: string
+    
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         files: CCUsageMac-${{ github.ref_name }}.dmg
         draft: false
         prerelease: false
-        generate_release_notes: true
+        body: ${{ steps.release-notes.outputs.result }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci-cd-guide.md
+++ b/docs/ci-cd-guide.md
@@ -1,0 +1,149 @@
+# CI/CD ガイド
+
+## 概要
+
+CCUsageMacプロジェクトでは、GitHub Actionsを使用した自動リリースシステムを採用しています。PRのラベルに基づいて自動的にバージョニング、タグ付け、リリースビルドが行われます。
+
+## リリースフロー
+
+### 1. 開発フロー
+
+```mermaid
+graph LR
+    A[Feature Branch] --> B[Pull Request]
+    B --> C{ラベル付与}
+    C --> D[master マージ]
+    D --> E[自動タグ作成]
+    E --> F[自動リリースビルド]
+    F --> G[GitHub Release]
+```
+
+### 2. ラベルによるバージョニング
+
+PRに以下のラベルを付けることで、自動的にバージョンが決定されます：
+
+| ラベル | バージョン変更 | 例 | 使用場面 |
+|--------|--------------|-----|----------|
+| `release:major` | メジャーバージョンアップ | 1.2.3 → 2.0.0 | 破壊的変更、大幅な仕様変更 |
+| `release:minor` | マイナーバージョンアップ | 1.2.3 → 1.3.0 | 新機能追加、機能拡張 |
+| `release:patch` | パッチバージョンアップ | 1.2.3 → 1.2.4 | バグ修正、小さな改善 |
+| `release:skip` | リリースなし | - | リリース不要な変更 |
+
+### 3. PR分類ラベル
+
+リリースノートの自動生成のために、PRの内容を分類するラベルも使用します：
+
+- `breaking-change` - 破壊的変更
+- `feature` - 新機能
+- `enhancement` - 既存機能の改善
+- `bug` / `fix` - バグ修正
+- `documentation` - ドキュメント変更
+- `ci` - CI/CD関連の変更
+
+## セットアップ
+
+### 1. ラベルの作成
+
+リポジトリに必要なラベルを作成します：
+
+```bash
+# リポジトリのルートディレクトリで実行
+bash .github/setup-labels.sh
+```
+
+### 2. リポジトリ設定
+
+1. **Settings > Actions > General** で以下を確認：
+   - "Allow GitHub Actions to create and approve pull requests" を有効化
+   - Workflow permissions を "Read and write permissions" に設定
+
+2. **Settings > Branches** でmasterブランチの保護ルールを設定（推奨）：
+   - Require pull request reviews before merging
+   - Dismiss stale pull request approvals when new commits are pushed
+   - Require status checks to pass before merging
+
+## 使用方法
+
+### 1. PR作成時
+
+```bash
+# feature ブランチで作業
+git checkout -b feature/new-feature
+# ... 変更を加える ...
+git add .
+git commit -m "Add new feature"
+git push origin feature/new-feature
+```
+
+### 2. PR にラベルを付ける
+
+GitHub UI または CLI でラベルを付与：
+
+```bash
+# GitHub CLI を使用する場合
+gh pr create --title "Add new feature" --label "release:minor" --label "feature"
+```
+
+### 3. マージ後の自動処理
+
+1. PRがmasterにマージされると、`prepare-release.yml` が起動
+2. ラベルに基づいて新しいバージョンを計算
+3. 新しいタグを作成してプッシュ
+4. タグプッシュにより `release.yml` が起動
+5. アプリをビルドし、DMGを作成
+6. GitHub Releaseを作成し、DMGを添付
+
+## ワークフロー詳細
+
+### prepare-release.yml
+
+- **トリガー**: PRのmasterへのマージ
+- **処理内容**:
+  - PRラベルの確認
+  - バージョン計算
+  - タグ作成
+  - PRへのコメント追加
+
+### release.yml
+
+- **トリガー**: `v*` タグのプッシュ
+- **処理内容**:
+  - macOSでのビルド
+  - アプリバンドル作成
+  - コード署名
+  - DMG作成
+  - リリースノート生成
+  - GitHub Release作成
+
+## トラブルシューティング
+
+### ラベルが認識されない
+
+- PRに正しいラベルが付いているか確認
+- `release:` プレフィックスが正しく付いているか確認
+
+### タグが作成されない
+
+- GitHub Actionsの権限を確認
+- ワークフローログでエラーを確認
+
+### ビルドが失敗する
+
+- Swift バージョンの互換性を確認
+- 依存関係の問題を確認
+- macOS のバージョン要件を確認
+
+## ベストプラクティス
+
+1. **明確なPRタイトル**: リリースノートに含まれるため、わかりやすいタイトルを付ける
+2. **適切なラベル付け**: バージョニングとカテゴリーの両方のラベルを付ける
+3. **Breaking Changesの明記**: 破壊的変更がある場合は必ず `breaking-change` ラベルを付ける
+4. **小さなPR**: レビューしやすく、問題の特定が容易
+5. **テストの実行**: マージ前に必ずテストを実行
+
+## 今後の拡張案
+
+- Conventional Commits の導入
+- 自動CHANGELOG生成
+- プレリリース（beta/rc）サポート
+- 複数プラットフォーム対応


### PR DESCRIPTION
## Summary
- 🚀 PRラベルベースの自動バージョニング・タグ作成機能を追加
- 📝 リリースノートの自動生成機能（カテゴリー分け対応）を追加
- 🏷️ 必要なGitHubラベルを一括作成するセットアップスクリプトを追加

## Changes
- `.github/workflows/prepare-release.yml` - PR マージ時の自動タグ作成ワークフロー
- `.github/workflows/release.yml` - リリースノート自動生成機能を追加
- `.github/setup-labels.sh` - GitHubラベル設定スクリプト
- `docs/ci-cd-guide.md` - CI/CD使用ガイド

## How it works
1. PRに `release:major`、`release:minor`、`release:patch` のいずれかのラベルを付ける
2. masterにマージすると自動的に適切なバージョンのタグが作成される
3. タグ作成により既存のリリースワークフローが起動し、ビルド・リリースが実行される

## Test plan
- [ ] ラベル設定スクリプト (`bash .github/setup-labels.sh`) を実行してラベルが作成されることを確認
- [ ] このPRに `release:minor` と `ci` ラベルを付けてマージし、自動タグ作成を確認
- [ ] 作成されたタグによりリリースビルドが正常に実行されることを確認
- [ ] リリースノートが適切に生成されることを確認

## Note
このPRがマージされたら、まず `bash .github/setup-labels.sh` を実行してラベルを作成する必要があります。

🤖 Generated with [Claude Code](https://claude.ai/code)